### PR TITLE
make installation of desktop experience optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Setting the `cleanmgr_install_reboot` value to `true` allows Ansible to reboot
 the target Windows computer after installing the Desktop Experience feature.
 Ansible doesn't get a result from `cleanmgr.exe` to know if it should reboot or not, so toggling `cleanmgr_cleanmgr_reboot` will always or never reboot after running `cleanmgr.exe`.
 
+    cleanmgr_install_desktop_experience: true
+
     cleanmgr_install_reboot: true
     cleanmgr_cleanmgr_reboot: false
     cleanmgr_sagerun: "0001"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@ cleanmgr_internet_cache_files: true
 cleanmgr_memory_dump_files: false
 cleanmgr_old_chkdsk_files: false
 cleanmgr_previous_installations: false
-cleanmgr_recycle_bin: true
+cleanmgr_recycle_bin: false
 cleanmgr_service_pack_cleanup: false
 cleanmgr_setup_log_files: false
 cleanmgr_system_error_memory_dump_files: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+cleanmgr_install_desktop_experience: true
 
 cleanmgr_install_reboot: true
 cleanmgr_cleanmgr_reboot: false
@@ -11,7 +12,7 @@ cleanmgr_internet_cache_files: true
 cleanmgr_memory_dump_files: false
 cleanmgr_old_chkdsk_files: false
 cleanmgr_previous_installations: false
-cleanmgr_recycle_bin: false
+cleanmgr_recycle_bin: true
 cleanmgr_service_pack_cleanup: false
 cleanmgr_setup_log_files: false
 cleanmgr_system_error_memory_dump_files: false

--- a/tasks/install-desktop-experience.yml
+++ b/tasks/install-desktop-experience.yml
@@ -1,0 +1,38 @@
+- name: "Install Desktop Experience feature."
+  win_feature:
+    name: "Desktop-Experience"
+    state: present
+    include_sub_features: yes
+  register: cleanmgr_desktop_experience_install
+  failed_when:
+    - cleanmgr_desktop_experience_install.failed is defined
+    - cleanmgr_desktop_experience_install.failed
+    - not cleanmgr_desktop_experience_install.exitcode == "FailedRestartRequired"
+
+- debug:
+    var: cleanmgr_desktop_experience_install
+    verbosity: 1
+
+- block:
+  - name: "Reboot Windows to re-try Desktop Experience install."
+    win_reboot:
+      shutdown_timeout_sec: 3600
+      reboot_timeout_sec: 3600
+
+  # Let it fail this time if reboot didn't work.
+  - name: "Install Desktop Experience again."
+    win_feature:
+      name: "Desktop-Experience"
+      state: present
+      include_sub_features: yes
+    register: cleanmgr_desktop_experience_install
+  when:
+    - cleanmgr_desktop_experience_install.exitcode is defined
+    - cleanmgr_desktop_experience_install.exitcode == "FailedRestartRequired"
+    - cleanmgr_install_reboot
+
+- name: Reboot to finish Desktop Experience install.
+  win_reboot:
+    shutdown_timeout_sec: 3600
+    reboot_timeout_sec: 3600
+  when: cleanmgr_install_reboot and ((cleanmgr_desktop_experience_install.reboot_required is defined and cleanmgr_desktop_experience_install.reboot_required) or (cleanmgr_desktop_experience_install.restart_needed is defined and cleanmgr_desktop_experience_install.restart_needed))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,44 +2,9 @@
 
 # https://stackoverflow.com/questions/28852786/automate-process-of-disk-cleanup-cleanmgr-exe-without-user-intervention#35214197
 
-- name: "Install Desktop Experience feature."
-  win_feature:
-    name: "Desktop-Experience"
-    state: present
-    include_sub_features: yes
-  register: cleanmgr_desktop_experience_install
-  failed_when:
-    - cleanmgr_desktop_experience_install.failed is defined
-    - cleanmgr_desktop_experience_install.failed
-    - not cleanmgr_desktop_experience_install.exitcode == "FailedRestartRequired"
-
-- debug:
-    var: cleanmgr_desktop_experience_install
-    verbosity: 1
-
-- block:
-  - name: "Reboot Windows to re-try Desktop Experience install."
-    win_reboot:
-      shutdown_timeout_sec: 3600
-      reboot_timeout_sec: 3600
-
-  # Let it fail this time if reboot didn't work.
-  - name: "Install Desktop Experience again."
-    win_feature:
-      name: "Desktop-Experience"
-      state: present
-      include_sub_features: yes
-    register: cleanmgr_desktop_experience_install
-  when:
-    - cleanmgr_desktop_experience_install.exitcode is defined
-    - cleanmgr_desktop_experience_install.exitcode == "FailedRestartRequired"
-    - cleanmgr_install_reboot
-
-- name: Reboot to finish Desktop Experience install.
-  win_reboot:
-    shutdown_timeout_sec: 3600
-    reboot_timeout_sec: 3600
-  when: cleanmgr_install_reboot and ((cleanmgr_desktop_experience_install.reboot_required is defined and cleanmgr_desktop_experience_install.reboot_required) or (cleanmgr_desktop_experience_install.restart_needed is defined and cleanmgr_desktop_experience_install.restart_needed))
+- name: include installation desktop experience
+  include_tasks: install-desktop-experience.yml
+  when: cleanmgr_install_desktop_experience
 
 - name: "Set Active Setup Temp Folders flag."
   win_regedit:


### PR DESCRIPTION
We found out that the installation of desktop experience is not necessary to run the cleanup, so we thought that it is a good idea to make it optional.